### PR TITLE
[2021-04-09]용석:QueryDSL 실습을 위한 예제 도메인 생성

### DIFF
--- a/src/main/java/io/example/querydsl/domain/Member.java
+++ b/src/main/java/io/example/querydsl/domain/Member.java
@@ -1,0 +1,35 @@
+package io.example.querydsl.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static lombok.AccessLevel.PROTECTED;
+
+/**
+ * @author : choi-ys
+ * @date : 2021-04-09 오후 3:24
+ * @Content : 회원을 표현하는 Entity
+ */
+@Entity @Table(name = "member_tb")
+@SequenceGenerator(
+        name = "MEMBER_ENTITY_SEQ_GENERATOR",
+        sequenceName = "MEMBER_ENTITY_SEQ",
+        initialValue = 1,
+        allocationSize = 1
+)
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Member {
+
+    @Id @GeneratedValue(generator = "MEMBER_ENTITY_SEQ_GENERATOR")
+    @Column(name = "member_no")
+    private Long no;
+
+    @Column(name = "member_name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name ="age", nullable = true)
+    private int age;
+}

--- a/src/main/java/io/example/querydsl/domain/Team.java
+++ b/src/main/java/io/example/querydsl/domain/Team.java
@@ -1,0 +1,44 @@
+package io.example.querydsl.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static lombok.AccessLevel.PROTECTED;
+
+/**
+ * @author : choi-ys
+ * @date : 2021-04-09 오후 3:32
+ * @Content : 팀을 표현하는 Entity
+ */
+@Entity @Table(name = "team_tb")
+@SequenceGenerator(
+        name = "TEAM_ENTITY_SEQ_GENERATOR",
+        sequenceName = "TEAM_ENTITY_SEQ",
+        initialValue = 1,
+        allocationSize = 1
+)
+@Getter @NoArgsConstructor(access = PROTECTED)
+public class Team {
+
+    @Id @GeneratedValue(generator = "TEAM_ENTITY_SEQ_GENERATOR")
+    @Column(name = "team_no")
+    private Long no;
+
+    @Column(name = "team_name", nullable = false, length = 20)
+    private String name;
+
+
+    // * --------------------------------------------------------------
+    // * Header : 도메인 생성
+    // * @author : choi-ys
+    // * @date : 2021/04/09 3:35 오후
+    // * --------------------------------------------------------------
+
+    @Builder
+    public Team(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/io/example/querydsl/QueryDslApplicationTests.java
+++ b/src/test/java/io/example/querydsl/QueryDslApplicationTests.java
@@ -2,8 +2,10 @@ package io.example.querydsl;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 
 @SpringBootTest
+@Profile("test")
 class QueryDslApplicationTests {
 
     @Test


### PR DESCRIPTION
 - 회원과 팀을 표현하는 Entity 클래스 생성
 - Entity 클래스와 DB 테이블 매핑 시 필요한 설정 적용
 - Sequence 명 및 초기값 설정
 - 테이블명 및 각 컬럼의 제약 조건 설정
 - Test 구동을 통한 Entity 관련 설정 적용 여부 확인

회원과 팀 Entity의 연관관계 설정
 - 연관관계의 주인 설정
 - 외래키 제약조건 이름 설정
 - 양방향 연관관계 설정에 따른 객체 값 설정 부 추가
 - 연관관계 설정으로 인한 회원 도메인 생성 부 수정(팀 도메인 설정)
