### PR TITLE
[2021-04-13]용석:Spring Data Jpa와 QueryDSL를 이용한 Repository 구현

### DIFF
--- a/src/main/java/io/example/querydsl/config/QueryDslConfig.java
+++ b/src/main/java/io/example/querydsl/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package io.example.querydsl.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/13 10:00 오전
+ * @Content : JPAQueryFactory Bean 주입 설정
+ */
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/io/example/querydsl/repository/MemberQueryRepository.java
+++ b/src/main/java/io/example/querydsl/repository/MemberQueryRepository.java
@@ -1,0 +1,20 @@
+package io.example.querydsl.repository;
+
+import io.example.querydsl.domain.dto.MemberTeamDto;
+import io.example.querydsl.domain.search.MemberSearchCondition;
+
+import java.util.List;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/13 9:55 오전
+ * @Content : Spring Data Jpa Repository와 QueryDSL을 같이 사용하기 위한 사용자 정의 Repository
+ *  - 1. 사용자 정의 Interface 작성 : {@link MemberQueryRepository}
+ *  - 2. 사용자 정의 Interface 구현 : {@link MemberSpringDataJpaRepositoryImpl}
+ *       - 명명규칙 : {상속할 Spring Data Repository} + Impl
+ *  - 3. Spring Data Repository에 사용자 정의 Interface 상속
+ */
+public interface MemberQueryRepository {
+
+    List<MemberTeamDto> searchMemberTeam(MemberSearchCondition memberSearchCondition);
+}

--- a/src/main/java/io/example/querydsl/repository/MemberSpringDataJpaRepository.java
+++ b/src/main/java/io/example/querydsl/repository/MemberSpringDataJpaRepository.java
@@ -1,0 +1,14 @@
+package io.example.querydsl.repository;
+
+import io.example.querydsl.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/13 9:48 오전
+ * @Content : Spring Data Jpa와 QueryDSL로 구성된 Repository
+ *  - Spring Data Jpa를 이용한 Repository는 interface이므로, 개발자가 구현한 개발 코드는
+ *  별도의 Repository로 작성하여 해당 Repository에 상속하여 의존관계를 분리한다.
+ */
+public interface MemberSpringDataJpaRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
+}

--- a/src/main/java/io/example/querydsl/repository/MemberSpringDataJpaRepositoryImpl.java
+++ b/src/main/java/io/example/querydsl/repository/MemberSpringDataJpaRepositoryImpl.java
@@ -1,0 +1,62 @@
+package io.example.querydsl.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.example.querydsl.domain.dto.MemberTeamDto;
+import io.example.querydsl.domain.dto.QMemberTeamDto;
+import io.example.querydsl.domain.search.MemberSearchCondition;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static io.example.querydsl.domain.QMember.member;
+import static io.example.querydsl.domain.QTeam.team;
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/13 9:55 오전
+ * @Content : Spring Data Jpa Repository에 상속할 사용자 정의 Repository Interface 구현체
+ *  - 목적 : Spring Data Jpa와 QueryDSL 사용을 위한 사용자 정의 Repository 구현
+ */
+@RequiredArgsConstructor
+public class MemberSpringDataJpaRepositoryImpl implements MemberQueryRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<MemberTeamDto> searchMemberTeam(MemberSearchCondition memberSearchCondition) {
+        return jpaQueryFactory
+                .select(new QMemberTeamDto(
+                        member.no.as("memberId"),
+                        member.name.as("memberName"),
+                        member.age.as("memberAge"),
+                        team.no.as("teamId"),
+                        team.name.as("teamName")
+                ))
+                .from(member)
+                .join(member.team, team)
+                .where(
+                        memberNameEQ(memberSearchCondition.getMemberName()),
+                        teamNameEq(memberSearchCondition.getTeamName()),
+                        memberAgeGoe(memberSearchCondition.getAgeGoe()),
+                        memberAgeLoe(memberSearchCondition.getAgeLoe())
+                ).fetch();
+    }
+
+    private BooleanExpression memberNameEQ(String memberName) {
+        return hasText(memberName) ? member.name.eq(memberName) : null;
+    }
+
+    private BooleanExpression teamNameEq(String teamName) {
+        return hasText(teamName) ? team.name.eq(teamName) : null;
+    }
+
+
+    private BooleanExpression memberAgeGoe(Integer ageGoe){
+        return ageGoe != null ? member.age.goe(ageGoe) : null;
+    }
+
+    private BooleanExpression memberAgeLoe(Integer ageLoe){
+        return ageLoe != null ? member.age.loe(ageLoe) : null;
+    }
+}

--- a/src/test/java/io/example/querydsl/ch19_spring_data_jpa_with_query_dsl/SpringDataJpaRepositoryWithQueryDsl.java
+++ b/src/test/java/io/example/querydsl/ch19_spring_data_jpa_with_query_dsl/SpringDataJpaRepositoryWithQueryDsl.java
@@ -1,0 +1,111 @@
+package io.example.querydsl.ch19_spring_data_jpa_with_query_dsl;
+
+import io.example.querydsl.config.BaseTest;
+import io.example.querydsl.domain.Member;
+import io.example.querydsl.domain.Team;
+import io.example.querydsl.domain.dto.MemberTeamDto;
+import io.example.querydsl.domain.search.MemberSearchCondition;
+import io.example.querydsl.generator.MemberGenerator;
+import io.example.querydsl.repository.MemberSpringDataJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/13 9:46 오전
+ * @Content : Spring Data Jpa와 QueryDSL로 구성된 Repository Test
+ */
+public class SpringDataJpaRepositoryWithQueryDsl extends BaseTest {
+
+    @Autowired
+    MemberSpringDataJpaRepository memberSpringDataJpaRepository;
+
+    @Test
+    @DisplayName("save")
+//    @Rollback(value = false)
+    public void save(){
+        // Given
+        Member member = MemberGenerator.getMember();
+
+        // When
+        Member savedMember = memberSpringDataJpaRepository.save(member);
+
+        // Then
+        assertEquals(savedMember, member);
+    }
+
+    @Test
+    @DisplayName("findById")
+//    @Rollback(value = false)
+    public void findById(){
+        // Given
+        Member savedMember = memberGenerator.savedMember();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        Optional<Member> optionalMember = memberSpringDataJpaRepository.findById(savedMember.getNo());
+        Member selectedMember = optionalMember.orElseThrow();
+
+        // Then
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+    }
+
+    @Test
+    @DisplayName("remove")
+//    @Rollback(value = false)
+    public void remove(){
+        // Given
+        Member savedMember = memberGenerator.savedMember();
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        memberSpringDataJpaRepository.delete(savedMember);
+
+        // Then
+        Optional<Member> optionalMember = memberSpringDataJpaRepository.findById(savedMember.getNo());
+
+        NoSuchElementException noSuchElementException = assertThrows(NoSuchElementException.class, () -> {
+            Member member = optionalMember.orElseThrow();
+            assertEquals(member, null);
+        });
+        assertEquals(noSuchElementException.getMessage(), "No value present");
+    }
+
+    @Test
+    @DisplayName("findMemberTeamDto By QueryDsl")
+//    @Rollback(value = false)
+    public void findMemberTeamDtoByQueryDsl(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+        memberGenerator.savedMemberWithTeam("이성욱", 31, savedTeam);
+        memberGenerator.savedMemberWithTeam("박재현", 29, savedTeam);
+        memberGenerator.savedMemberWithTeam("이하은", 29, savedTeam);
+
+        // When
+        MemberSearchCondition memberSearchCondition = new MemberSearchCondition();
+        memberSearchCondition.setMemberName("박재현");
+        memberSearchCondition.setTeamName("CoreDevTeam");
+        memberSearchCondition.setAgeGoe(20);
+        memberSearchCondition.setAgeLoe(30);
+
+        List<MemberTeamDto> memberTeamDtoList = memberSpringDataJpaRepository.searchMemberTeam(memberSearchCondition);
+
+        // Then
+        assertThat(memberTeamDtoList)
+                .extracting("memberName").containsExactly("박재현");
+    }
+}


### PR DESCRIPTION
 - Spring Data Jpa와 QueryDSL 사용을 위한 사용자 정의 Repository 정의 및 구현
   - MemberSpringDataJpaRepository : Spring Data Jpa
   - MemberQueryRepository : 사용자 정의 Repository 정의 부
   - MemberSpringDataJpaRepositoryImpl : 사용자 정의 Repository 구현